### PR TITLE
Python2.4 compatibility

### DIFF
--- a/bottlenose/api.py
+++ b/bottlenose/api.py
@@ -1,9 +1,27 @@
 from base64 import b64encode
-from hashlib import sha256
+import sys
 import urllib
 import urllib2
 import hmac
 import time
+
+
+from hashlib import sha256
+
+# Python 2.4 compatibility
+# http://code.google.com/p/boto/source/detail?r=1011
+if sys.version[:3] == "2.4":
+    # we are using an hmac that expects a .new() method.
+    class Faker:
+        def __init__(self, which):
+            self.which = which
+            self.digest_size = self.which().digest_size
+
+        def new(self, *args, **kwargs):
+            return self.which(*args, **kwargs)
+	
+    sha256 = Faker(sha256)
+
 
 from exceptions import Exception
 


### PR DESCRIPTION
Since python2.4 hashlib backport have small incompatibilities, some changes required to make bottlenose works.

I took the code portion from here - http://code.google.com/p/boto/source/detail?r=1011

Hope, you found it useful.
