### PR TITLE
Allow unicode for search terms

### DIFF
--- a/bottlenose/api.py
+++ b/bottlenose/api.py
@@ -75,7 +75,7 @@ class AmazonCall(object):
         keys = kwargs.keys()
         keys.sort()
 
-        quoted_strings = "&".join("%s=%s" % (k, urllib.quote(str(kwargs[k]).encode('utf-8'), safe = '~')) for k in keys)
+        quoted_strings = "&".join("%s=%s" % (k, urllib.quote(unicode(kwargs[k]).encode('utf-8'), safe = '~')) for k in keys)
 
         data = "GET\n" + service_domain + "\n/onca/xml\n" + quoted_strings
 


### PR DESCRIPTION
I was having a problem with using unicode for the Keywords argument in an ItemSearch.  This change allows me to search for things like "Beyoncé"

Andrew.
