### PR TITLE
A possible fix for Cart Create

### DIFF
--- a/bottlenose/api.py
+++ b/bottlenose/api.py
@@ -2,6 +2,7 @@ from base64 import b64encode
 import gzip
 import sys
 import urllib
+import re
 try:
     import urllib2
 except ImportError:
@@ -84,6 +85,12 @@ class AmazonCall(object):
         kwargs['Version'] = self.Version
         kwargs['AWSAccessKeyId'] = self.AWSAccessKeyId
         kwargs['Service'] = "AWSECommerceService"
+        
+        for arg in kwargs:
+            if re.match(r'Item_(\d+)_(OfferListingId|Quantity)',str(arg)) != None:
+                new_arg_name = arg.replace('_','.')
+                kwargs[new_arg_name] = kwargs[arg]
+                kwargs.pop(arg)
 
         if self.Style:
             kwargs['Style'] = self.Style


### PR DESCRIPTION
...api:

Item.N.OfferListingId=[Item identifier]
Item.N.Quantity=[Number of Item.N items]

The further details are on page #139 of Amazon's Developer Guide API for Product Advertising.
My solution is to accept the input params in the following format: Item_N_OfferListingId or Item_N_Quantity.
Once passed in the names are corrected back to periods and loaded into kwargs.
I'm sure there is a more succinct solution.
