### PR TITLE
Fail loudly with specific errors on AWS misconfiguration.

### DIFF
--- a/bottlenose/api.py
+++ b/bottlenose/api.py
@@ -105,10 +105,19 @@ class AmazonCall(object):
 
         self.AWSAccessKeyId = (AWSAccessKeyId or
                                os.environ.get('AWS_ACCESS_KEY_ID'))
+        if self.AWSAccessKeyId is None:
+            raise TypeError("AWSAccessKeyId is not defined.")
+
         self.AWSSecretAccessKey = (AWSSecretAccessKey or
                                    os.environ.get('AWS_SECRET_ACCESS_KEY'))
+        if self.AWSSecretAccessKey is None:
+            raise TypeError("AWSSecretAccessKey is not defined.")
+
         self.AssociateTag = (AssociateTag or
                              os.environ.get('AWS_ASSOCIATE_TAG'))
+        if self.AssociateTag is None:
+            raise TypeError("AssociateTag is not defined.")
+
         self.CacheReader = CacheReader
         self.CacheWriter = CacheWriter
         self.ErrorHandler = ErrorHandler


### PR DESCRIPTION
Thanks for building this! I'm actually using bottlenose via [python-amazon-simple-product-api](https://github.com/yoavaviram/python-amazon-simple-product-api)

I was having an issue with a cryptic TypeError in my application `TypeError("object of type 'NoneType' has no len()",)`. It turned out to be because my AMAZON_SECRET_KEY_ID was getting unset elsewhere in my app.

This PR raises a specific TypeError when any of the various Amazon credentials is misconfigured which would have greatly simplified debugging.