### PR TITLE
Travis CI: Remove EOL versions of Python and add 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: python
 python:
-  - "3.2"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
-
+matrix:
+  include:
+    - python: "3.7"
+      dist: xenial    # required for Python >= 3.7 (travis-ci/travis-ci#9069)
+      sudo: required  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
 script:
   - make test


### PR DESCRIPTION
Remove versions of Python that have reached their end of life and add Python 3.7 in alignment with travis-ci/travis-ci#9069